### PR TITLE
my attempt to resolve #17

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -281,7 +281,6 @@ exports.validate = internals.validate = function (email, options, callback) {
     let token;                                      // Token is used outside the loop, must declare similarly
     for (let i = 0; i < emailLength; ++i) {
         token = email[i];
-
         switch (context.now) {
             // Local-part
             case internals.components.localpart:
@@ -463,7 +462,7 @@ exports.validate = internals.validate = function (email, options, callback) {
                             charCode = token.charCodeAt(0);
 
                             // Especially if charCode == 10
-                            if (charCode < 33 || charCode > 126 || internals.specials(charCode)) {
+                            if (charCode < 33 || internals.specials(charCode) || charCode > 65535 ) {
 
                                 // Fatal error
                                 updateResult(internals.diagnoses.errExpectingATEXT);
@@ -662,7 +661,7 @@ exports.validate = internals.validate = function (email, options, callback) {
                         // Assume this token isn't a hyphen unless we discover it is
                         hyphenFlag = false;
 
-                        if (charCode < 33 || charCode > 126 || internals.specials(charCode)) {
+                        if (charCode < 33 || internals.specials(charCode)) {
                             // Fatal error
                             updateResult(internals.diagnoses.errExpectingATEXT);
                         }
@@ -675,7 +674,8 @@ exports.validate = internals.validate = function (email, options, callback) {
                             hyphenFlag = true;
                         }
                             // Check if it's a neither a number nor a latin letter
-                        else if (charCode < 48 || charCode > 122 || (charCode > 57 && charCode < 65) || (charCode > 90 && charCode < 97)) {
+                            // Check for '{' charCode 123 and '}' charCode 125
+                        else if (charCode < 48 || (charCode > 57 && charCode < 65) || (charCode > 90 && charCode < 97) || (charCode === 123 || charCode === 125) || charCode > 65535) {
                             // This is not an RFC 5321 subdomain, but still OK by RFC 5322
                             updateResult(internals.diagnoses.rfc5322Domain);
                         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,7 +12,9 @@ const internals = {
     indexOf: Array.prototype.indexOf,
     defaultThreshold: 16,
     maxIPv6Groups: 8,
-
+    unicode:{
+        maxNumber :65535
+    },
     categories: {
         valid: 1,
         dnsWarn: 7,
@@ -462,7 +464,7 @@ exports.validate = internals.validate = function (email, options, callback) {
                             charCode = token.charCodeAt(0);
 
                             // Especially if charCode == 10
-                            if (charCode < 33 || internals.specials(charCode) || charCode > 65535 ) {
+                            if (charCode < 33 || internals.specials(charCode) || charCode > internals.unicode.maxNumber) {
 
                                 // Fatal error
                                 updateResult(internals.diagnoses.errExpectingATEXT);
@@ -661,7 +663,7 @@ exports.validate = internals.validate = function (email, options, callback) {
                         // Assume this token isn't a hyphen unless we discover it is
                         hyphenFlag = false;
 
-                        if (charCode < 33 || internals.specials(charCode)) {
+                        if (charCode < 33 || charCode > internals.unicode.maxNumber) {
                             // Fatal error
                             updateResult(internals.diagnoses.errExpectingATEXT);
                         }
@@ -675,7 +677,7 @@ exports.validate = internals.validate = function (email, options, callback) {
                         }
                             // Check if it's a neither a number nor a latin letter
                             // Check for '{' charCode 123 and '}' charCode 125
-                        else if (charCode < 48 || (charCode > 57 && charCode < 65) || (charCode > 90 && charCode < 97) || (charCode === 123 || charCode === 125) || charCode > 65535) {
+                        else if (charCode < 48 || (charCode > 57 && charCode < 65) || (charCode > 90 && charCode < 97) || (charCode === 123 || charCode === 125) || charCode > internals.unicode.maxNumber) {
                             // This is not an RFC 5321 subdomain, but still OK by RFC 5322
                             updateResult(internals.diagnoses.rfc5322Domain);
                         }

--- a/test/tests.json
+++ b/test/tests.json
@@ -127,8 +127,8 @@
     ["test@[RFC-5322-domain-literal\\", "errBackslashEnd"],
     ["test@[RFC 5322 domain literal]", "rfc5322DomainLiteral"],
     ["test@[RFC-5322-domain-literal] (comment)", "rfc5322DomainLiteral"],
-    ["@iana.org", "errExpectingATEXT"],
-    ["test@.org", "errExpectingATEXT"],
+    ["@iana.org", "errNoLocalPart"],
+    ["test@.org", "errDotStart"],
     ["\"\"@iana.org", "deprecatedQTEXT"],
     ["\"\"@iana.org", "errExpectingQTEXT"],
     ["\"\\\"@iana.org", "deprecatedQP"],
@@ -183,5 +183,10 @@
     ["(comment\r\n comment)test@iana.org", "cfwsFWS"],
     ["test@org", "rfc5321TLD"],
     ["test@example.com", "dnsWarnNoMXRecord"],
-    ["test@nic.no", "dnsWarnNoRecord"]
+    ["test@nic.no", "dnsWarnNoRecord"],
+    ["êjness@iana.com", "dnsWarnNoMXRecord"],
+    ["ñoñó1234@iana.com", "dnsWarnNoMXRecord"],
+    ["ñoñó1234@something.com", "valid"],
+    ["ñoñó1234@ñomething.com", "dnsWarnNoRecord"],
+    ["伊昭傑@郵件.商務", "dnsWarnNoRecord"]
 ]


### PR DESCRIPTION
- my attempt to resolve #17 to cover unicode email address with characters uptil Integer 65535 as returned by charCodeAt( ) , in localpart and domain.
- added 5 unicode test cases at the end.
- updated 2 old test cases cases from 
  
  ```
  ["@iana.org", "errExpectingATEXT"],
  ["test@.org", "errExpectingATEXT"]
  ```
  
  to

```
    ["@iana.org", "errNoLocalPart"],
    ["test@.org", "errDotStart"]
```
