### PR TITLE
Internal polyfill for Buffer to enable usage in browser

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -251,7 +251,8 @@ internals.stringToUtf8 = function (input) {
 
             // valid surrogate pair
             codePoint = (leadSurrogate - 0xD800 << 10 | codePoint - 0xDC00) + 0x10000;
-        } else if (leadSurrogate) {
+        }
+        else if (leadSurrogate) {
             // valid bmp char, but last char was a lead
             bytes.push(0xEF, 0xBF, 0xBD);
         }
@@ -295,7 +296,8 @@ if (typeof Buffer === 'object' && typeof Buffer.byteLength === 'function') {
 
         return Buffer.byteLength(input, 'utf8');
     };
-} else {
+}
+else {
     internals.byteLength = function (input) {
 
         return internals.stringToUtf8(input).length;

--- a/lib/index.js
+++ b/lib/index.js
@@ -213,6 +213,84 @@ internals.validDomain = function (tldAtom, options) {
     return internals.hasOwn.call(options.tldWhitelist, tldAtom);
 };
 
+internals.stringToUtf8 = (input) => {
+    var codePoint
+    var length = input.length
+    var leadSurrogate = null
+    var bytes = []
+  
+    for (var i = 0; i < length; ++i) {
+      codePoint = input.charCodeAt(i)
+  
+      // is surrogate component
+      if (codePoint > 0xD7FF && codePoint < 0xE000) {
+        // last char was a lead
+        if (!leadSurrogate) {
+          // no lead yet
+          if (codePoint > 0xDBFF) {
+            // unexpected trail
+            bytes.push(0xEF, 0xBF, 0xBD)
+            continue
+          } else if (i + 1 === length) {
+            // unpaired lead
+            bytes.push(0xEF, 0xBF, 0xBD)
+            continue
+          }
+  
+          // valid lead
+          leadSurrogate = codePoint
+          continue
+        }
+  
+        // 2 leads in a row
+        if (codePoint < 0xDC00) {
+          bytes.push(0xEF, 0xBF, 0xBD)
+          leadSurrogate = codePoint
+          continue
+        }
+  
+        // valid surrogate pair
+        codePoint = (leadSurrogate - 0xD800 << 10 | codePoint - 0xDC00) + 0x10000
+      } else if (leadSurrogate) {
+        // valid bmp char, but last char was a lead
+        bytes.push(0xEF, 0xBF, 0xBD)
+      }
+  
+      leadSurrogate = null
+  
+      // encode utf8
+      if (codePoint < 0x80) {
+        bytes.push(codePoint)
+      } else if (codePoint < 0x800) {
+        bytes.push(
+          codePoint >> 0x6 | 0xC0,
+          codePoint & 0x3F | 0x80
+        )
+      } else if (codePoint < 0x10000) {
+        bytes.push(
+          codePoint >> 0xC | 0xE0,
+          codePoint >> 0x6 & 0x3F | 0x80,
+          codePoint & 0x3F | 0x80
+        )
+      } else if (codePoint < 0x110000) {
+        bytes.push(
+          codePoint >> 0x12 | 0xF0,
+          codePoint >> 0xC & 0x3F | 0x80,
+          codePoint >> 0x6 & 0x3F | 0x80,
+          codePoint & 0x3F | 0x80
+        )
+      } else {
+        throw new Error('Invalid code point')
+      }
+    }
+    return bytes
+  }
+
+if (typeof Buffer === 'object' && typeof Buffer.byteLength === 'function') {
+    internals.byteLength = (input) => Buffer.byteLength(input, 'utf8');
+} else {
+    internals.byteLength = (input) => internals.stringToUtf8(input).length;
+}
 
 /**
  * Check that an email address conforms to RFCs 5321, 5322, 6530 and others
@@ -397,7 +475,7 @@ exports.validate = internals.validate = function (email, options, callback) {
 
                             parseData.local += token;
                             atomData.locals[elementCount] += token;
-                            elementLength += Buffer.byteLength(token, 'utf8');
+                            elementLength += internals.byteLength(token);
 
                             // Quoted string must be the entire element
                             assertEnd = true;
@@ -453,7 +531,7 @@ exports.validate = internals.validate = function (email, options, callback) {
                         }
                         // http://tools.ietf.org/html/rfc5321#section-4.5.3.1.1 the maximum total length of a user name or other local-part is 64
                         //    octets
-                        else if (Buffer.byteLength(parseData.local, 'utf8') > 64) {
+                        else if (internals.byteLength(parseData.local) > 64) {
                             updateResult(internals.diagnoses.rfc5322LocalTooLong);
                         }
                         // http://tools.ietf.org/html/rfc5322#section-3.4.1 comments and folding white space SHOULD NOT be used around "@" in the
@@ -520,7 +598,7 @@ exports.validate = internals.validate = function (email, options, callback) {
 
                             parseData.local += token;
                             atomData.locals[elementCount] += token;
-                            elementLength += Buffer.byteLength(token, 'utf8');
+                            elementLength += internals.byteLength(token);
                         }
                 }
 
@@ -622,7 +700,7 @@ exports.validate = internals.validate = function (email, options, callback) {
                         if (parseData.domain.length === 0) {
                             // Domain literal must be the only component
                             assertEnd = true;
-                            elementLength += Buffer.byteLength(token, 'utf8');
+                            elementLength += internals.byteLength(token);
                             context.stack.push(context.now);
                             context.now = internals.components.literal;
                             parseData.domain += token;
@@ -730,7 +808,7 @@ exports.validate = internals.validate = function (email, options, callback) {
 
                         parseData.domain += token;
                         atomData.domains[elementCount] += token;
-                        elementLength += Buffer.byteLength(token, 'utf8');
+                        elementLength += internals.byteLength(token);
                 }
 
                 break;
@@ -867,7 +945,7 @@ exports.validate = internals.validate = function (email, options, callback) {
 
                         parseData.domain += token;
                         atomData.domains[elementCount] += token;
-                        elementLength += Buffer.byteLength(token, 'utf8');
+                        elementLength += internals.byteLength(token);
                         context.prev = context.now;
                         context.now = context.stack.pop();
                         break;
@@ -925,7 +1003,7 @@ exports.validate = internals.validate = function (email, options, callback) {
                         parseData.literal += token;
                         parseData.domain += token;
                         atomData.domains[elementCount] += token;
-                        elementLength += Buffer.byteLength(token, 'utf8');
+                        elementLength += internals.byteLength(token);
                 }
 
                 break;
@@ -968,7 +1046,7 @@ exports.validate = internals.validate = function (email, options, callback) {
 
                         parseData.local += ' ';
                         atomData.locals[elementCount] += ' ';
-                        elementLength += Buffer.byteLength(token, 'utf8');
+                        elementLength += internals.byteLength(token);
 
                         updateResult(internals.diagnoses.cfwsFWS);
                         context.stack.push(context.now);
@@ -980,7 +1058,7 @@ exports.validate = internals.validate = function (email, options, callback) {
                     case '"':
                         parseData.local += token;
                         atomData.locals[elementCount] += token;
-                        elementLength += Buffer.byteLength(token, 'utf8');
+                        elementLength += internals.byteLength(token);
                         context.prev = context.now;
                         context.now = context.stack.pop();
                         break;
@@ -1011,7 +1089,7 @@ exports.validate = internals.validate = function (email, options, callback) {
 
                         parseData.local += token;
                         atomData.locals[elementCount] += token;
-                        elementLength += Buffer.byteLength(token, 'utf8');
+                        elementLength += internals.byteLength(token);
                 }
 
                 // http://tools.ietf.org/html/rfc5322#section-3.4.1
@@ -1271,7 +1349,7 @@ exports.validate = internals.validate = function (email, options, callback) {
             //   The maximum total length of a domain name or number is 255 octets.
             updateResult(internals.diagnoses.rfc5322DomainTooLong);
         }
-        else if (Buffer.byteLength(parseData.local, 'utf8') + punycodeLength + /* '@' */ 1 > 254) {
+        else if (internals.byteLength(parseData.local) + punycodeLength + /* '@' */ 1 > 254) {
             // http://tools.ietf.org/html/rfc5321#section-4.1.2
             //   Forward-path   = Path
             //

--- a/lib/index.js
+++ b/lib/index.js
@@ -213,7 +213,7 @@ internals.validDomain = function (tldAtom, options) {
     return internals.hasOwn.call(options.tldWhitelist, tldAtom);
 };
 
-internals.stringToUtf8 = (input) => {
+internals.stringToUtf8 = function (input) {
     var codePoint
     var length = input.length
     var leadSurrogate = null
@@ -284,12 +284,16 @@ internals.stringToUtf8 = (input) => {
       }
     }
     return bytes
-  }
+  };
 
 if (typeof Buffer === 'object' && typeof Buffer.byteLength === 'function') {
-    internals.byteLength = (input) => Buffer.byteLength(input, 'utf8');
+    internals.byteLength = function (input) { 
+        return Buffer.byteLength(input, 'utf8');
+    }
 } else {
-    internals.byteLength = (input) => internals.stringToUtf8(input).length;
+    internals.byteLength = function (input) {
+        return internals.stringToUtf8(input).length;
+    };
 }
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -214,84 +214,90 @@ internals.validDomain = function (tldAtom, options) {
 };
 
 internals.stringToUtf8 = function (input) {
-    var codePoint
-    var length = input.length
-    var leadSurrogate = null
-    var bytes = []
-  
-    for (var i = 0; i < length; ++i) {
-      codePoint = input.charCodeAt(i)
-  
-      // is surrogate component
-      if (codePoint > 0xD7FF && codePoint < 0xE000) {
-        // last char was a lead
-        if (!leadSurrogate) {
-          // no lead yet
-          if (codePoint > 0xDBFF) {
-            // unexpected trail
-            bytes.push(0xEF, 0xBF, 0xBD)
-            continue
-          } else if (i + 1 === length) {
-            // unpaired lead
-            bytes.push(0xEF, 0xBF, 0xBD)
-            continue
-          }
-  
-          // valid lead
-          leadSurrogate = codePoint
-          continue
+
+    const length = input.length;
+    let leadSurrogate = null;
+    const bytes = [];
+
+    for (let i = 0; i < length; ++i) {
+        let codePoint = input.charCodeAt(i);
+
+        // is surrogate component
+        if (codePoint > 0xD7FF && codePoint < 0xE000) {
+            // last char was a lead
+            if (!leadSurrogate) {
+                // no lead yet
+                if (codePoint > 0xDBFF) {
+                    // unexpected trail
+                    bytes.push(0xEF, 0xBF, 0xBD);
+                    continue;
+                }
+                else if (i + 1 === length) {
+                    // unpaired lead
+                    bytes.push(0xEF, 0xBF, 0xBD);
+                    continue;
+                }
+                // valid lead
+                leadSurrogate = codePoint;
+                continue;
+            }
+
+            // 2 leads in a row
+            if (codePoint < 0xDC00) {
+                bytes.push(0xEF, 0xBF, 0xBD);
+                leadSurrogate = codePoint;
+                continue;
+            }
+
+            // valid surrogate pair
+            codePoint = (leadSurrogate - 0xD800 << 10 | codePoint - 0xDC00) + 0x10000;
+        } else if (leadSurrogate) {
+            // valid bmp char, but last char was a lead
+            bytes.push(0xEF, 0xBF, 0xBD);
         }
-  
-        // 2 leads in a row
-        if (codePoint < 0xDC00) {
-          bytes.push(0xEF, 0xBF, 0xBD)
-          leadSurrogate = codePoint
-          continue
+
+        leadSurrogate = null;
+
+        // encode utf8
+        if (codePoint < 0x80) {
+            bytes.push(codePoint);
         }
-  
-        // valid surrogate pair
-        codePoint = (leadSurrogate - 0xD800 << 10 | codePoint - 0xDC00) + 0x10000
-      } else if (leadSurrogate) {
-        // valid bmp char, but last char was a lead
-        bytes.push(0xEF, 0xBF, 0xBD)
-      }
-  
-      leadSurrogate = null
-  
-      // encode utf8
-      if (codePoint < 0x80) {
-        bytes.push(codePoint)
-      } else if (codePoint < 0x800) {
-        bytes.push(
-          codePoint >> 0x6 | 0xC0,
-          codePoint & 0x3F | 0x80
-        )
-      } else if (codePoint < 0x10000) {
-        bytes.push(
-          codePoint >> 0xC | 0xE0,
-          codePoint >> 0x6 & 0x3F | 0x80,
-          codePoint & 0x3F | 0x80
-        )
-      } else if (codePoint < 0x110000) {
-        bytes.push(
-          codePoint >> 0x12 | 0xF0,
-          codePoint >> 0xC & 0x3F | 0x80,
-          codePoint >> 0x6 & 0x3F | 0x80,
-          codePoint & 0x3F | 0x80
-        )
-      } else {
-        throw new Error('Invalid code point')
-      }
+        else if (codePoint < 0x800) {
+            bytes.push(
+                codePoint >> 0x6 | 0xC0,
+                codePoint & 0x3F | 0x80
+            );
+        }
+        else if (codePoint < 0x10000) {
+            bytes.push(
+                codePoint >> 0xC | 0xE0,
+                codePoint >> 0x6 & 0x3F | 0x80,
+                codePoint & 0x3F | 0x80
+            );
+        }
+        else if (codePoint < 0x110000) {
+            bytes.push(
+                codePoint >> 0x12 | 0xF0,
+                codePoint >> 0xC & 0x3F | 0x80,
+                codePoint >> 0x6 & 0x3F | 0x80,
+                codePoint & 0x3F | 0x80
+            );
+        }
+        else {
+            throw new Error('Invalid code point');
+        }
     }
-    return bytes
-  };
+    return bytes;
+};
 
 if (typeof Buffer === 'object' && typeof Buffer.byteLength === 'function') {
-    internals.byteLength = function (input) { 
+    internals.byteLength = function (input) {
+
         return Buffer.byteLength(input, 'utf8');
-    }
+    };
 } else {
     internals.byteLength = function (input) {
+
         return internals.stringToUtf8(input).length;
     };
 }
@@ -449,7 +455,7 @@ exports.validate = internals.validate = function (email, options, callback) {
                         context.now = internals.components.contextComment;
                         break;
 
-                        // Next dot-atom element
+                    // Next dot-atom element
                     case '.':
                         if (elementLength === 0) {
                             // Another dot, already?
@@ -471,7 +477,7 @@ exports.validate = internals.validate = function (email, options, callback) {
 
                         break;
 
-                        // Quoted string
+                    // Quoted string
                     case '"':
                         if (elementLength === 0) {
                             // The entire local-part can be a quoted string for RFC 5321; if one atom is quoted it's an RFC 5322 obsolete form
@@ -492,7 +498,7 @@ exports.validate = internals.validate = function (email, options, callback) {
 
                         break;
 
-                        // Folding white space
+                    // Folding white space
                     case '\r':
                         if (emailLength === ++i || email[i] !== '\n') {
                             // Fatal error
@@ -500,7 +506,7 @@ exports.validate = internals.validate = function (email, options, callback) {
                             break;
                         }
 
-                        // Fallthrough
+                    // Fallthrough
 
                     case ' ':
                     case '\t':
@@ -557,7 +563,7 @@ exports.validate = internals.validate = function (email, options, callback) {
                         assertEnd = false; // CFWS can only appear at the end of the element
                         break;
 
-                        // ATEXT
+                    // ATEXT
                     default:
                         // http://tools.ietf.org/html/rfc5322#section-3.2.3
                         //    atext = ALPHA / DIGIT / ; Printable US-ASCII
@@ -583,10 +589,10 @@ exports.validate = internals.validate = function (email, options, callback) {
                                     updateResult(internals.diagnoses.errATEXTAfterQS);
                                     break;
 
-                                    // $lab:coverage:off$
+                                // $lab:coverage:off$
                                 default:
                                     throw new Error('more atext found where none is allowed, but unrecognized prev context: ' + context.prev);
-                                    // $lab:coverage:on$
+                                // $lab:coverage:on$
                             }
                         }
                         else {
@@ -667,7 +673,7 @@ exports.validate = internals.validate = function (email, options, callback) {
                         context.now = internals.components.contextComment;
                         break;
 
-                        // Next dot-atom element
+                    // Next dot-atom element
                     case '.':
                         const punycodeLength = Punycode.encode(atomData.domains[elementCount]).length;
                         if (elementLength === 0) {
@@ -699,7 +705,7 @@ exports.validate = internals.validate = function (email, options, callback) {
 
                         break;
 
-                        // Domain literal
+                    // Domain literal
                     case '[':
                         if (parseData.domain.length === 0) {
                             // Domain literal must be the only component
@@ -718,7 +724,7 @@ exports.validate = internals.validate = function (email, options, callback) {
 
                         break;
 
-                        // Folding white space
+                    // Folding white space
                     case '\r':
                         if (emailLength === ++i || email[i] !== '\n') {
                             // Fatal error
@@ -726,7 +732,7 @@ exports.validate = internals.validate = function (email, options, callback) {
                             break;
                         }
 
-                        // Fallthrough
+                    // Fallthrough
 
                     case ' ':
                     case '\t':
@@ -744,7 +750,7 @@ exports.validate = internals.validate = function (email, options, callback) {
                         prevToken = token;
                         break;
 
-                        // This must be ATEXT
+                    // This must be ATEXT
                     default:
                         // RFC 5322 allows any atext...
                         // http://tools.ietf.org/html/rfc5322#section-3.2.3
@@ -781,10 +787,10 @@ exports.validate = internals.validate = function (email, options, callback) {
                                     updateResult(internals.diagnoses.errATEXTAfterDomainLiteral);
                                     break;
 
-                                    // $lab:coverage:off$
+                                // $lab:coverage:off$
                                 default:
                                     throw new Error('more atext found where none is allowed, but unrecognized prev context: ' + context.prev);
-                                    // $lab:coverage:on$
+                                // $lab:coverage:on$
                             }
                         }
 
@@ -817,7 +823,7 @@ exports.validate = internals.validate = function (email, options, callback) {
 
                 break;
 
-                // Domain literal
+            // Domain literal
             case internals.components.literal:
                 // http://tools.ietf.org/html/rfc5322#section-3.4.1
                 //   domain-literal  =   [CFWS] "[" *([FWS] dtext) [FWS] "]" [CFWS]
@@ -960,14 +966,14 @@ exports.validate = internals.validate = function (email, options, callback) {
                         context.now = internals.components.contextQuotedPair;
                         break;
 
-                        // Folding white space
+                    // Folding white space
                     case '\r':
                         if (emailLength === ++i || email[i] !== '\n') {
                             updateResult(internals.diagnoses.errCRNoLF);
                             break;
                         }
 
-                        // Fallthrough
+                    // Fallthrough
 
                     case ' ':
                     case '\t':
@@ -978,7 +984,7 @@ exports.validate = internals.validate = function (email, options, callback) {
                         prevToken = token;
                         break;
 
-                        // DTEXT
+                    // DTEXT
                     default:
                         // http://tools.ietf.org/html/rfc5322#section-3.4.1
                         //   dtext         =   %d33-90 /  ; Printable US-ASCII
@@ -1012,7 +1018,7 @@ exports.validate = internals.validate = function (email, options, callback) {
 
                 break;
 
-                // Quoted string
+            // Quoted string
             case internals.components.contextQuotedString:
                 // http://tools.ietf.org/html/rfc5322#section-3.2.4
                 //   quoted-string = [CFWS]
@@ -1027,7 +1033,7 @@ exports.validate = internals.validate = function (email, options, callback) {
                         context.now = internals.components.contextQuotedPair;
                         break;
 
-                        // Folding white space. Spaces are allowed as regular characters inside a quoted string - it's only FWS if we include '\t' or '\r\n'
+                    // Folding white space. Spaces are allowed as regular characters inside a quoted string - it's only FWS if we include '\t' or '\r\n'
                     case '\r':
                         if (emailLength === ++i || email[i] !== '\n') {
                             // Fatal error
@@ -1035,7 +1041,7 @@ exports.validate = internals.validate = function (email, options, callback) {
                             break;
                         }
 
-                        // Fallthrough
+                    // Fallthrough
 
                     case '\t':
                         // http://tools.ietf.org/html/rfc5322#section-3.2.2
@@ -1058,7 +1064,7 @@ exports.validate = internals.validate = function (email, options, callback) {
                         prevToken = token;
                         break;
 
-                        // End of quoted string
+                    // End of quoted string
                     case '"':
                         parseData.local += token;
                         atomData.locals[elementCount] += token;
@@ -1067,7 +1073,7 @@ exports.validate = internals.validate = function (email, options, callback) {
                         context.now = context.stack.pop();
                         break;
 
-                        // QTEXT
+                    // QTEXT
                     default:
                         // http://tools.ietf.org/html/rfc5322#section-3.2.4
                         //   qtext          =   %d33 /             ; Printable US-ASCII
@@ -1103,7 +1109,7 @@ exports.validate = internals.validate = function (email, options, callback) {
                 //   string form SHOULD NOT be used.
 
                 break;
-                // Quoted pair
+            // Quoted pair
             case internals.components.contextQuotedPair:
                 // http://tools.ietf.org/html/rfc5322#section-3.2.1
                 //   quoted-pair     =   ("\" (VCHAR / WSP)) / obs-qp
@@ -1122,7 +1128,7 @@ exports.validate = internals.validate = function (email, options, callback) {
                 // i.e. obs-qp       =  "\" (%d0-8, %d10-31 / %d127)
                 charCode = token.codePointAt(0);
 
-                if (charCode !== 127 &&  internals.c1Controls(charCode)) {
+                if (charCode !== 127 && internals.c1Controls(charCode)) {
                     // Fatal error
                     updateResult(internals.diagnoses.errExpectingQPair);
                 }
@@ -1160,14 +1166,14 @@ exports.validate = internals.validate = function (email, options, callback) {
                         elementLength += 2;
                         break;
 
-                        // $lab:coverage:off$
+                    // $lab:coverage:off$
                     default:
                         throw new Error('quoted pair logic invoked in an invalid context: ' + context.now);
-                        // $lab:coverage:on$
+                    // $lab:coverage:on$
                 }
                 break;
 
-                // Comment
+            // Comment
             case internals.components.contextComment:
                 // http://tools.ietf.org/html/rfc5322#section-3.2.2
                 //   comment  = "(" *([FWS] ccontent) [FWS] ")"
@@ -1181,19 +1187,19 @@ exports.validate = internals.validate = function (email, options, callback) {
                         context.now = internals.components.contextComment;
                         break;
 
-                        // End of comment
+                    // End of comment
                     case ')':
                         context.prev = context.now;
                         context.now = context.stack.pop();
                         break;
 
-                        // Quoted pair
+                    // Quoted pair
                     case '\\':
                         context.stack.push(context.now);
                         context.now = internals.components.contextQuotedPair;
                         break;
 
-                        // Folding white space
+                    // Folding white space
                     case '\r':
                         if (emailLength === ++i || email[i] !== '\n') {
                             // Fatal error
@@ -1201,7 +1207,7 @@ exports.validate = internals.validate = function (email, options, callback) {
                             break;
                         }
 
-                        // Fallthrough
+                    // Fallthrough
 
                     case ' ':
                     case '\t':
@@ -1212,7 +1218,7 @@ exports.validate = internals.validate = function (email, options, callback) {
                         prevToken = token;
                         break;
 
-                        // CTEXT
+                    // CTEXT
                     default:
                         // http://tools.ietf.org/html/rfc5322#section-3.2.3
                         //   ctext         = %d33-39 /  ; Printable US-ASCII
@@ -1241,7 +1247,7 @@ exports.validate = internals.validate = function (email, options, callback) {
 
                 break;
 
-                // Folding white space
+            // Folding white space
             case internals.components.contextFWS:
                 // http://tools.ietf.org/html/rfc5322#section-3.2.2
                 //   FWS     =   ([*WSP CRLF] 1*WSP) /  obs-FWS
@@ -1305,11 +1311,11 @@ exports.validate = internals.validate = function (email, options, callback) {
                 prevToken = token;
                 break;
 
-                // Unexpected context
-                // $lab:coverage:off$
+            // Unexpected context
+            // $lab:coverage:off$
             default:
                 throw new Error('unknown context: ' + context.now);
-                // $lab:coverage:on$
+            // $lab:coverage:on$
         } // Primary state machine
 
         if (maxResult > internals.categories.rfc5322) {


### PR DESCRIPTION
This library uses single function from the Node Buffer module, namely Buffer.byteLength. For environments other than (relatively recent) Node a polyfill is needed to provide this module/global. It seems rather complicated to use a full Buffer polyfill to provide single rather simple function. 

Thus this pull request contains function stringToUtf8, modified from https://github.com/feross/buffer, which polyfills Buffer.byteLength as well as code to switch between Buffer and polyfill based on availability of said module.