### PR TITLE
Implement IDN-aware case insensitive TLD check

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@
 // Load modules
 
 const Punycode = require('punycode');
+const Util = require('util');
 
 // Declare internals
 
@@ -196,21 +197,101 @@ internals.checkIpV6 = function (items) {
 };
 
 
+// Node 10 introduced isSet and isMap, which are useful for cross-context type
+// checking.
+// $lab:coverage:off$
+internals._isSet = (value) => value instanceof Set;
+internals._isMap = (value) => value instanceof Map;
+internals.isSet = Util.types && Util.types.isSet || internals._isSet;
+internals.isMap = Util.types && Util.types.isMap || internals._isMap;
+// $lab:coverage:on$
+
+
+/**
+ * Normalize the given lookup "table" to an iterator. Outputs items in arrays
+ * and sets, keys from maps (regardless of the corresponding value), and own
+ * enumerable keys from all other objects (intended to be plain objects).
+ *
+ * @param {*} table The table to convert.
+ * @returns {Iterable<*>} The converted table.
+ */
+internals.normalizeTable = function (table) {
+
+    if (internals.isSet(table) || Array.isArray(table)) {
+        return table;
+    }
+
+    if (internals.isMap(table)) {
+        return table.keys();
+    }
+
+    return Object.keys(table);
+};
+
+
+/**
+ * Convert the given domain atom to its canonical form using Nameprep and string
+ * lowercasing. Domain atoms that are all-ASCII will not undergo any changes via
+ * Nameprep, and domain atoms that have already been canonicalized will not be
+ * altered.
+ *
+ * @param {string} atom The atom to canonicalize.
+ * @returns {string} The canonicalized atom.
+ */
+internals.canonicalizeAtom = function (atom) {
+
+    return Punycode.toASCII(atom).toLowerCase();
+};
+
+
+/**
+ * Check whether any of the values in the given iterable, when passed through
+ * the iteratee function, are equal to the given value.
+ *
+ * @param {Iterable<*>} iterable The iterable to check.
+ * @param {function(*): *} iteratee The iteratee that receives each item from
+ *   the iterable.
+ * @param {*} value The reference value.
+ * @returns {boolean} Whether the given value matches any of the items in the
+ *   iterable per the iteratee.
+ */
+internals.includesMapped = function (iterable, iteratee, value) {
+
+    for (const item of iterable) {
+        if (value === iteratee(item)) {
+            return true;
+        }
+    }
+    return false;
+};
+
+
+/**
+ * Check whether the given top-level domain atom is valid based on the
+ * configured blacklist/whitelist.
+ *
+ * @param {string} tldAtom The atom to check.
+ * @param {Object} options
+ *   {*} tldBlacklist The set of domains to consider invalid.
+ *   {*} tldWhitelist The set of domains to consider valid.
+ * @returns {boolean} Whether the given domain atom is valid per the blacklist/
+ *   whitelist.
+ */
 internals.validDomain = function (tldAtom, options) {
 
+    // Nameprep handles case-sensitive unicode stuff, but doesn't touch
+    // uppercase ASCII characters.
+    const canonicalTldAtom = internals.canonicalizeAtom(tldAtom);
+
     if (options.tldBlacklist) {
-        if (Array.isArray(options.tldBlacklist)) {
-            return internals.indexOf.call(options.tldBlacklist, tldAtom) === -1;
-        }
-
-        return !internals.hasOwn.call(options.tldBlacklist, tldAtom);
+        return !internals.includesMapped(
+            internals.normalizeTable(options.tldBlacklist),
+            internals.canonicalizeAtom, canonicalTldAtom);
     }
 
-    if (Array.isArray(options.tldWhitelist)) {
-        return internals.indexOf.call(options.tldWhitelist, tldAtom) !== -1;
-    }
-
-    return internals.hasOwn.call(options.tldWhitelist, tldAtom);
+    return internals.includesMapped(
+        internals.normalizeTable(options.tldWhitelist),
+        internals.canonicalizeAtom, canonicalTldAtom);
 };
 
 

--- a/test/index.js
+++ b/test/index.js
@@ -43,9 +43,29 @@ expectations.push(['test@[\0', diag.errExpectingDTEXT]);
 expectations.push(['(\0)test@example.com', diag.errExpectingCTEXT]);
 
 
-const tldExpectations = [
+const asciiTldExpectations = [
+    // Test ASCII-only domains.
     ['shouldbe@invalid', diag.errUnknownTLD],
-    ['shouldbe@example.com', diag.valid]
+    ['shouldbe@INVALID', diag.errUnknownTLD],
+    ['shouldbe@example.com', diag.valid],
+    ['shouldbe@example.COM', diag.valid]
+];
+
+const unicodeTldExpectations = [
+    // Test non-latin domains that have no (current) case-change support in unicode.
+    ['shouldbe@XN--UNUP4Y', diag.valid],
+    ['shouldbe@xn--unup4y', diag.valid],
+    ['shouldbe@\u6e38\u620f', diag.valid],
+    ['shouldbe@xn--tckwe', diag.errUnknownTLD],
+    ['shouldbe@XN--TCKWE', diag.errUnknownTLD],
+    ['shouldbe@\u30b3\u30e0', diag.errUnknownTLD],
+    // Test non-latin domains that have current case-change support in unicode.
+    ['shouldbe@verm\u00f6gensberatung', diag.valid],
+    ['shouldbe@xn--vermgensberatung-pwb', diag.valid],
+    ['shouldbe@XN--VERMGENSBERATUNG-PWB', diag.valid],
+    ['shouldbe@VERM\u00d6GENSBERATUNG', diag.errUnknownTLD],
+    ['shouldbe@xn--vermgensberatung-5gb', diag.errUnknownTLD],
+    ['shouldbe@XN--VERMGENSBERATUNG-5GB', diag.errUnknownTLD]
 ];
 
 describe('validate()', () => {
@@ -59,6 +79,14 @@ describe('validate()', () => {
         expect(Isemail.validate('person@top', {
             tldWhitelist: ['com']
         })).to.equal(false);
+
+        expect(Isemail.validate('person@top', {
+            tldWhitelist: new Set(['top'])
+        })).to.equal(true);
+
+        expect(Isemail.validate('person@top', {
+            tldWhitelist: new Map([['top', false]])
+        })).to.equal(true);
 
         expect(Isemail.validate('person@top', {
             tldWhitelist: { com: true }
@@ -172,7 +200,7 @@ describe('validate()', () => {
         });
     });
 
-    tldExpectations.forEach((obj, i) => {
+    asciiTldExpectations.forEach((obj, i) => {
 
         const email = obj[0];
         const result = obj[1];
@@ -199,6 +227,30 @@ describe('validate()', () => {
                 tldBlacklist: ['invalid']
             })).to.equal(result);
 
+        });
+    });
+
+    unicodeTldExpectations.forEach((obj, i) => {
+
+        const email = obj[0];
+        const result = obj[1];
+
+        it('should handle unicode tld test (' + email + ') ' + (i + 1), () => {
+
+            expect(Isemail.validate(email, {
+                errorLevel: 0,
+                tldWhitelist: ['xn--unup4y', 'xn--vermgensberatung-pwb']
+            })).to.equal(result);
+
+            expect(Isemail.validate(email, {
+                errorLevel: 0,
+                tldWhitelist: ['XN--UNUP4Y', 'XN--VERMGENSBERATUNG-PWB']
+            })).to.equal(result);
+
+            expect(Isemail.validate(email, {
+                errorLevel: 0,
+                tldWhitelist: ['\u6e38\u620f', 'verm\u00f6gensberatung']
+            })).to.equal(result);
         });
     });
 

--- a/test/index.js
+++ b/test/index.js
@@ -48,7 +48,9 @@ const asciiTldExpectations = [
     ['shouldbe@invalid', diag.errUnknownTLD],
     ['shouldbe@INVALID', diag.errUnknownTLD],
     ['shouldbe@example.com', diag.valid],
-    ['shouldbe@example.COM', diag.valid]
+    ['shouldbe@example.COM', diag.valid],
+    // Regression test for https://github.com/hapijs/isemail/issues/170.
+    ['apple-touch-icon-60x60@2x.png', diag.errUnknownTLD]
 ];
 
 const unicodeTldExpectations = [
@@ -219,12 +221,12 @@ describe('validate()', () => {
 
             expect(Isemail.validate(email, {
                 errorLevel: 0,
-                tldBlacklist: { invalid: true }
+                tldBlacklist: { invalid: true, png: true }
             })).to.equal(result);
 
             expect(Isemail.validate(email, {
                 errorLevel: 0,
-                tldBlacklist: ['invalid']
+                tldBlacklist: ['invalid', 'png']
             })).to.equal(result);
 
         });


### PR DESCRIPTION
Fixes #170. This relies on punycode to deal with canonicalizing IDNs, and makes
the domain comparison ASCII-only lowercase.

cc @VeeeneX - does this solve your problem in #170?