### PR TITLE
Allow address literals to bypass minDomainAtoms

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1377,7 +1377,7 @@ exports.validate = internals.validate = function (email, options, callback) {
             // labels   63 octets or less
             updateResult(internals.diagnoses.rfc5322LabelTooLong);
         }
-        else if (options.minDomainAtoms && atomData.domains.length < options.minDomainAtoms) {
+        else if (options.minDomainAtoms && atomData.domains.length < options.minDomainAtoms && (atomData.domains.length !== 1 || atomData.domains[0][0] !== '[')) {
             updateResult(internals.diagnoses.errDomainTooShort);
         }
         else if (options.tldWhitelist || options.tldBlacklist) {

--- a/test/index.js
+++ b/test/index.js
@@ -189,6 +189,20 @@ describe('validate()', () => {
         expect(Isemail.validate(expectations[0][0])).to.equal(expectations[0][1] < internals.defaultThreshold);
     });
 
+    it('should permit address literals with multiple required domain atoms', () => {
+
+        expect(Isemail.validate('joe@[IPv6:2a00:1450:4001:c02::1b]', {
+            minDomainAtoms: 2,
+            errorLevel: true
+        })).to.equal(diag.rfc5321AddressLiteral);
+
+        // Do not provide the same treatment to mixed domain parts.
+        expect(Isemail.validate('joe@[IPv6:2a00:1450:4001:c02::1b].com', {
+            minDomainAtoms: 3,
+            errorLevel: true
+        })).to.equal(diag.errDomainTooShort);
+    });
+
     expectations.forEach((obj, i) => {
 
         const email = obj[0];


### PR DESCRIPTION
Do not consider the number of atoms in an address with an address literal as its only domain part. Thus, validating `joe@[IPv6:2a00:1450:4001:c02::1b]` yields the diagnosis `rfc5321AddressLiteral` when `minDomainAtoms` is `2`, instead of the fatal `errDomainTooShort`.

If we decide that this behavior should generalize beyond just one address literal, then we should discuss that separately. As it stands, these are two vaguely defined behaviors, one of which isn't formally specified.

For #180.