### PR TITLE
Fix punycode import

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,7 @@
 
 // Load modules
 
-const Punycode = require('punycode');
+const Punycode = require('punycode/'); // Load the userland punycode module over the core Node module.
 const Util = require('util');
 
 // Declare internals


### PR DESCRIPTION
We currently use the built-in (and deprecated) `punycode` module instead of the userland dependency we pull in. Per https://github.com/bestiejs/punycode.js/issues/79#issuecomment-373773560, we can simply add a slash to force Node's resolution algorithm to ignore the core module.